### PR TITLE
Add CGAL geodesic path editing mode

### DIFF
--- a/Compute/CGAL_Geodesic_Path.cpp
+++ b/Compute/CGAL_Geodesic_Path.cpp
@@ -1,0 +1,48 @@
+#include "CGAL_Geodesic_Path.h"
+
+CGAL_Geodesic_Path::CGAL_Geodesic_Path(const Mesh& mesh)
+    : mesh_(mesh)
+{
+    build_cgal_mesh();
+}
+
+void CGAL_Geodesic_Path::build_cgal_mesh()
+{
+    vmap_.reserve(mesh_.n_vertices());
+    for (const VH& v : mesh_.vertices())
+    {
+        const auto& p = mesh_.point(v);
+        vmap_.push_back(cgal_mesh_.add_vertex(Point_3(p[0], p[1], p[2])));
+    }
+
+    for (const FH& f : mesh_.faces())
+    {
+        std::vector<SurfaceMesh::Vertex_index> face;
+        for (auto fv_it = mesh_.cfv_iter(f); fv_it.is_valid(); ++fv_it)
+        {
+            face.push_back(vmap_[fv_it->idx()]);
+        }
+        if (face.size() == 3)
+            cgal_mesh_.add_face(face);
+    }
+}
+
+void CGAL_Geodesic_Path::ComputePath(const VH& start, const VH& end)
+{
+    path_points_.clear();
+
+    typedef CGAL::Surface_mesh_shortest_path_traits<Kernel, SurfaceMesh> Traits;
+    typedef CGAL::Surface_mesh_shortest_path<Traits> Shortest_path;
+    Shortest_path shortest_paths(cgal_mesh_);
+
+    shortest_paths.add_source_point(vmap_[start.idx()]);
+
+    std::list<Point_3> points;
+    shortest_paths.shortest_path_points_to_source_points(vmap_[end.idx()], std::back_inserter(points));
+
+    for (const Point_3& p : points)
+    {
+        path_points_.push_back(OpenMesh::Vec3d(p.x(), p.y(), p.z()));
+    }
+}
+

--- a/Compute/CGAL_Geodesic_Path.h
+++ b/Compute/CGAL_Geodesic_Path.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+#include <list>
+#include "../MeshViewer/MeshDefinition.h"
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Surface_mesh_shortest_path.h>
+
+class CGAL_Geodesic_Path
+{
+public:
+    CGAL_Geodesic_Path(const Mesh& mesh);
+    ~CGAL_Geodesic_Path() = default;
+
+    void ComputePath(const VH& start, const VH& end);
+
+    std::vector<OpenMesh::Vec3d> return_path() const { return path_points_; }
+
+private:
+    typedef CGAL::Simple_cartesian<double> Kernel;
+    typedef Kernel::Point_3 Point_3;
+    typedef CGAL::Surface_mesh<Point_3> SurfaceMesh;
+
+    void build_cgal_mesh();
+
+    const Mesh& mesh_;
+    SurfaceMesh cgal_mesh_;
+    std::vector<SurfaceMesh::Vertex_index> vmap_;
+    std::vector<OpenMesh::Vec3d> path_points_;
+};
+

--- a/MeshViewer/InteractiveViewerWidget.cpp
+++ b/MeshViewer/InteractiveViewerWidget.cpp
@@ -29,6 +29,8 @@ InteractiveViewerWidget::~InteractiveViewerWidget()
 
 	if (dij_path) delete dij_path;
 
+        if (geo_path) delete geo_path;
+
 	if (seam_mesh_) delete seam_mesh_;
 }
 
@@ -67,7 +69,17 @@ void InteractiveViewerWidget::mouseMoveEvent(QMouseEvent *_event)
 				temp_path = dij_path->return_path();
 			}
 		}
-		else
+		else if (edit_mode_ == EditMode::GEODESIC_EDIT)
+                {
+                        pick_vertex(_event->x(), _event->y());
+                        temp_end_v = VH(lastestVertex);
+                        if (start_v.size() != 0)
+                        {
+                                geo_path->ComputePath(start_v.back(), temp_end_v);
+                                temp_geo_path = geo_path->return_path();
+                        }
+                }
+                else
 		{
 			MeshViewerWidget::mouseMoveEvent(_event);
 		}
@@ -91,6 +103,12 @@ void InteractiveViewerWidget::mouseReleaseEvent(QMouseEvent *_event)
 
 			//lastestVertex = -1;
 		}
+                else if (edit_mode_ == EditMode::GEODESIC_EDIT && lastestVertex != -1)
+                {
+                        temp_end_v = VH(lastestVertex);
+                        start_v.push_back(temp_end_v);
+                        geo_path_points.push_back(temp_geo_path);
+                }
 		else
 		{
 			MeshViewerWidget::mouseReleaseEvent(_event);
@@ -127,7 +145,7 @@ void InteractiveViewerWidget::dropEvent(QDropEvent* event)
 
 	if (fileName.endsWith(".off") || fileName.endsWith(".obj") || fileName.endsWith(".stl") || fileName.endsWith(".ply"))
 	{
-		//obj文件的目录
+		//obj募目录
 		fileDirPath = fileName.toStdString();
 		fileDirPath = fileDirPath.substr(0, fileDirPath.find_last_of("//"));
 		std::string mesh_name = fileName.toStdString().substr(fileName.toStdString().find_last_of("//"), fileName.toStdString().length());
@@ -140,17 +158,17 @@ void InteractiveViewerWidget::dropEvent(QDropEvent* event)
 
 		std::string patch_path = "Patches\\Patches";
 
-		if (_access((patch_path).c_str(), 0) != -1)//不存在
+		if (_access((patch_path).c_str(), 0) != -1)//
 		{
 			std::string cmd = "rmdir /Q /S " + patch_path;
 			system(cmd.c_str());
 			while (_access((patch_path).c_str(), 0) != -1)
 			{
-				std::cout << "删除中" << std::endl;
-				//等待删除完成
+				std::cout << "删" << std::endl;
+				//却删
 			}
 		}
-		//新建文件夹
+		//陆募
 		std::string cmd = "mkdir " + patch_path;
 		system(cmd.c_str());
 		cmd = "mkdir " + patch_path + "\\Patch_Para";
@@ -656,6 +674,19 @@ void InteractiveViewerWidget::draw_scene(int drawmode)
 				glVertex3dv(mesh.point(vh1).data());
 			}
 		}
+                for (const auto& single_path : geo_path_points)
+                {
+                        for (size_t i = 1; i < single_path.size(); ++i)
+                        {
+                                glVertex3dv(single_path[i - 1].data());
+                                glVertex3dv(single_path[i].data());
+                        }
+                }
+                for (size_t i = 1; i < temp_geo_path.size(); ++i)
+                {
+                        glVertex3dv(temp_geo_path[i - 1].data());
+                        glVertex3dv(temp_geo_path[i].data());
+                }
 		for (const HEH& he_h : temp_path)
 		{
 			auto vh0 = mesh.from_vertex_handle(he_h);

--- a/MeshViewer/InteractiveViewerWidget.h
+++ b/MeshViewer/InteractiveViewerWidget.h
@@ -4,6 +4,7 @@
 #include "MeshViewerWidget.h"
 #include "ANN\ANN.h"
 #include "Compute\Dijkstra_Path.h"
+#include "Compute\CGAL_Geodesic_Path.h"
 #include "Compute\CutMesh.h"
 #include "Compute\SeamMesh.h"
 #include <io.h>
@@ -33,6 +34,8 @@ public:
 			
 			if (dij_path) delete dij_path;
 			dij_path = new Dijkstra_Path(mesh);
+                        if (geo_path) delete geo_path;
+                        geo_path = new CGAL_Geodesic_Path(mesh);
 			
 			if (seam_mesh_) delete seam_mesh_;
 			seam_mesh_ = new SeamMesh(mesh);
@@ -44,6 +47,8 @@ public:
 			path_he.clear();
 			temp_path.clear();
 			temp_end_v = VH(-1);
+                        geo_path_points.clear();
+                        temp_geo_path.clear();
 		}
 
 		return read_status;
@@ -284,10 +289,16 @@ public slots:
 	}
 
 	void SeamEdit()
-	{
-		std::cout << "Seam edit!" << std::endl;
-		edit_mode_ = EditMode::SEAM_EDIT;
-	}
+        {
+                std::cout << "Seam edit!" << std::endl;
+                edit_mode_ = EditMode::SEAM_EDIT;
+        }
+
+        void GeodesicEdit()
+        {
+                std::cout << "Geodesic edit!" << std::endl;
+                edit_mode_ = EditMode::GEODESIC_EDIT;
+        }
 
 	void AddSeam()
 	{
@@ -317,41 +328,60 @@ public slots:
 		update();
 	}
 
-	void UndoSeam()
-	{
-		std::cout << "Undo Seam Edit!" << std::endl;
+        void UndoSeam()
+        {
+                std::cout << "Undo Seam Edit!" << std::endl;
 
-		if (edit_mode_ == EditMode::NON_EDIT)
-		{
-			cut_mesh_->UndoAdd();
+                if (edit_mode_ == EditMode::NON_EDIT)
+                {
+                        cut_mesh_->UndoAdd();
 
-			start_v.clear();
-			path_he.clear();
-			temp_path.clear();
-			temp_end_v = VH(-1);
-		}
-		else if (edit_mode_ == EditMode::SEAM_EDIT)
-		{
-			if (path_he.size() > 0)
-			{
-				path_he.pop_back();
-				start_v.pop_back();
+                        start_v.clear();
+                        path_he.clear();
+                        temp_path.clear();
+                        temp_end_v = VH(-1);
+                        geo_path_points.clear();
+                        temp_geo_path.clear();
+                }
+                else if (edit_mode_ == EditMode::SEAM_EDIT)
+                {
+                        if (path_he.size() > 0)
+                        {
+                                path_he.pop_back();
+                                start_v.pop_back();
 
-				temp_path.clear();
-				temp_end_v = VH(-1);
-			}
-			else if (start_v.size() > 0)
-			{
-				start_v.pop_back();
+                                temp_path.clear();
+                                temp_end_v = VH(-1);
+                        }
+                        else if (start_v.size() > 0)
+                        {
+                                start_v.pop_back();
 
-				temp_path.clear();
-				temp_end_v = VH(-1);
-			}
-		}
+                                temp_path.clear();
+                                temp_end_v = VH(-1);
+                        }
+                }
+                else if (edit_mode_ == EditMode::GEODESIC_EDIT)
+                {
+                        if (geo_path_points.size() > 0)
+                        {
+                                geo_path_points.pop_back();
+                                start_v.pop_back();
 
-		update();
-	}
+                                temp_geo_path.clear();
+                                temp_end_v = VH(-1);
+                        }
+                        else if (start_v.size() > 0)
+                        {
+                                start_v.pop_back();
 
+                                temp_geo_path.clear();
+                                temp_end_v = VH(-1);
+                        }
+                }
+
+                update();
+        }
 	void MeshCut()
 	{
 		std::cout << "Mesh Cut!" << std::endl;
@@ -590,7 +620,7 @@ public:
 private:
 	std::string fileDirPath = "";
 
-	enum class EditMode {NON_EDIT, SEAM_EDIT};
+	enum class EditMode {NON_EDIT, SEAM_EDIT, GEODESIC_EDIT};
 	EditMode edit_mode_ = EditMode::NON_EDIT;
 
 	std::vector<OpenMesh::VertexHandle> start_v;
@@ -599,6 +629,9 @@ private:
 	std::vector<OpenMesh::HalfedgeHandle> temp_path;
 
 	Dijkstra_Path* dij_path = NULL;
+        std::vector<std::vector<OpenMesh::Vec3d>> geo_path_points;
+        std::vector<OpenMesh::Vec3d> temp_geo_path;
+        CGAL_Geodesic_Path* geo_path = NULL;
 
 	int cur_patch_id = 0;
 

--- a/MeshViewer/MainViewerWidget.cpp
+++ b/MeshViewer/MainViewerWidget.cpp
@@ -39,10 +39,11 @@ void MainViewerWidget::initViewerWindow()
 
 	connect(MeshParam, SIGNAL(print_info_signal()), SLOT(print_info()));
 	
-	connect(MeshParam, SIGNAL(NoEditSignal()), MeshViewer, SLOT(NoEdit()));
-	connect(MeshParam, SIGNAL(SeamEditSignal()), MeshViewer, SLOT(SeamEdit()));
-	connect(MeshParam, SIGNAL(AddSeamSignal()), MeshViewer, SLOT(AddSeam()));
-	connect(MeshParam, SIGNAL(UndoSeamSignal()), MeshViewer, SLOT(UndoSeam()));
+        connect(MeshParam, SIGNAL(NoEditSignal()), MeshViewer, SLOT(NoEdit()));
+        connect(MeshParam, SIGNAL(SeamEditSignal()), MeshViewer, SLOT(SeamEdit()));
+        connect(MeshParam, SIGNAL(GeodesicEditSignal()), MeshViewer, SLOT(GeodesicEdit()));
+        connect(MeshParam, SIGNAL(AddSeamSignal()), MeshViewer, SLOT(AddSeam()));
+        connect(MeshParam, SIGNAL(UndoSeamSignal()), MeshViewer, SLOT(UndoSeam()));
 	connect(MeshParam, SIGNAL(MeshCutSignal()), MeshViewer, SLOT(MeshCut()));
 	connect(MeshViewer, SIGNAL(ResetEditSignal()), MeshParam, SLOT(ResetEdit()));
 

--- a/MeshViewer/MeshParamDialog.cpp
+++ b/MeshViewer/MeshParamDialog.cpp
@@ -67,17 +67,21 @@ void MeshParamDialog::CreateCutMeshBox(void)
 {
 	cut_mesh_box_ = new QGroupBox("Cut Mesh");
 
-	rb_non_edit_ = new QRadioButton(tr("Non"));
-	connect(rb_non_edit_, SIGNAL(clicked()), SIGNAL(NoEditSignal()));
+        rb_non_edit_ = new QRadioButton(tr("Non"));
+        connect(rb_non_edit_, SIGNAL(clicked()), SIGNAL(NoEditSignal()));
 
-	rb_seam_edit_ = new QRadioButton(tr("Edit"));
-	connect(rb_seam_edit_, SIGNAL(clicked()), SIGNAL(SeamEditSignal()));
+        rb_seam_edit_ = new QRadioButton(tr("Dijkstra Edit"));
+        connect(rb_seam_edit_, SIGNAL(clicked()), SIGNAL(SeamEditSignal()));
 
-	QButtonGroup* bg_show_ = new QButtonGroup();
-	bg_show_->setExclusive(true);
-	rb_non_edit_->setChecked(true);
-	bg_show_->addButton(rb_non_edit_);
-	bg_show_->addButton(rb_seam_edit_);
+        rb_geodesic_edit_ = new QRadioButton(tr("Geodesic Edit"));
+        connect(rb_geodesic_edit_, SIGNAL(clicked()), SIGNAL(GeodesicEditSignal()));
+
+        QButtonGroup* bg_show_ = new QButtonGroup();
+        bg_show_->setExclusive(true);
+        rb_non_edit_->setChecked(true);
+        bg_show_->addButton(rb_non_edit_);
+        bg_show_->addButton(rb_seam_edit_);
+        bg_show_->addButton(rb_geodesic_edit_);
 
 	QPushButton* pb_add = new QPushButton(tr("Add"));
 	connect(pb_add, SIGNAL(clicked()), SIGNAL(AddSeamSignal()));
@@ -88,12 +92,13 @@ void MeshParamDialog::CreateCutMeshBox(void)
 	QPushButton* pb_cut = new QPushButton(tr("Mesh Cut"));
 	connect(pb_cut, SIGNAL(clicked()), SIGNAL(MeshCutSignal()));
 
-	QGridLayout* layout_field = new QGridLayout();
-	layout_field->addWidget(rb_non_edit_, 0, 0, 1, 1);
-	layout_field->addWidget(rb_seam_edit_, 0, 1, 1, 1);
-	layout_field->addWidget(pb_undo, 1, 0, 1, 1);
-	layout_field->addWidget(pb_add, 1, 1, 1, 1);
-	layout_field->addWidget(pb_cut, 2, 0, 1, 2);
+        QGridLayout* layout_field = new QGridLayout();
+        layout_field->addWidget(rb_non_edit_, 0, 0, 1, 1);
+        layout_field->addWidget(rb_seam_edit_, 0, 1, 1, 1);
+        layout_field->addWidget(rb_geodesic_edit_, 0, 2, 1, 1);
+        layout_field->addWidget(pb_undo, 1, 0, 1, 1);
+        layout_field->addWidget(pb_add, 1, 1, 1, 1);
+        layout_field->addWidget(pb_cut, 2, 0, 1, 3);
 
 	cut_mesh_box_->setLayout(layout_field);
 }

--- a/MeshViewer/MeshParamDialog.h
+++ b/MeshViewer/MeshParamDialog.h
@@ -23,13 +23,14 @@ private:
 	QTabWidget* tabWidget;
 
 signals:
-	void print_info_signal();
+        void print_info_signal();
 
-	void NoEditSignal();
-	void SeamEditSignal();
-	void AddSeamSignal();
-	void UndoSeamSignal();
-	void MeshCutSignal();
+        void NoEditSignal();
+        void SeamEditSignal();
+        void GeodesicEditSignal();
+        void AddSeamSignal();
+        void UndoSeamSignal();
+        void MeshCutSignal();
 
 	void ChooseModelSignal(int);
 	
@@ -54,10 +55,11 @@ private:
 	void createWidget();
 	void createLayout();
 
-	void CreateCutMeshBox(void);
-	QGroupBox* cut_mesh_box_;
-	QRadioButton* rb_non_edit_;
-	QRadioButton* rb_seam_edit_;
+        void CreateCutMeshBox(void);
+        QGroupBox* cut_mesh_box_;
+        QRadioButton* rb_non_edit_;
+        QRadioButton* rb_seam_edit_;
+        QRadioButton* rb_geodesic_edit_;
 
 	void CreateViewPatchBox(void);
 	QGroupBox* view_patch_box_;


### PR DESCRIPTION
## Summary
- Integrate CGAL geodesic path computation for mesh editing
- Support new geodesic edit mode in interactive viewer with path visualization

## Testing
- `g++ -std=c++17 -IInclude -IMeshViewer -ICompute Compute/CGAL_Geodesic_Path.cpp -c`

------
https://chatgpt.com/codex/tasks/task_e_68b9e2f20f1083319c11a87a2b7aa0e3