### PR TITLE
Add geodesic edit mode button

### DIFF
--- a/MeshViewer/MainViewerWidget.cpp
+++ b/MeshViewer/MainViewerWidget.cpp
@@ -39,10 +39,11 @@ void MainViewerWidget::initViewerWindow()
 
 	connect(MeshParam, SIGNAL(print_info_signal()), SLOT(print_info()));
 	
-	connect(MeshParam, SIGNAL(NoEditSignal()), MeshViewer, SLOT(NoEdit()));
-	connect(MeshParam, SIGNAL(SeamEditSignal()), MeshViewer, SLOT(SeamEdit()));
-	connect(MeshParam, SIGNAL(AddSeamSignal()), MeshViewer, SLOT(AddSeam()));
-	connect(MeshParam, SIGNAL(UndoSeamSignal()), MeshViewer, SLOT(UndoSeam()));
+        connect(MeshParam, SIGNAL(NoEditSignal()), MeshViewer, SLOT(NoEdit()));
+        connect(MeshParam, SIGNAL(SeamEditSignal()), MeshViewer, SLOT(SeamEdit()));
+        connect(MeshParam, SIGNAL(GeodesicEditSignal()), MeshViewer, SLOT(GeodesicEdit()));
+        connect(MeshParam, SIGNAL(AddSeamSignal()), MeshViewer, SLOT(AddSeam()));
+        connect(MeshParam, SIGNAL(UndoSeamSignal()), MeshViewer, SLOT(UndoSeam()));
 	connect(MeshParam, SIGNAL(MeshCutSignal()), MeshViewer, SLOT(MeshCut()));
 	connect(MeshViewer, SIGNAL(ResetEditSignal()), MeshParam, SLOT(ResetEdit()));
 

--- a/MeshViewer/MeshParamDialog.cpp
+++ b/MeshViewer/MeshParamDialog.cpp
@@ -67,17 +67,21 @@ void MeshParamDialog::CreateCutMeshBox(void)
 {
 	cut_mesh_box_ = new QGroupBox("Cut Mesh");
 
-	rb_non_edit_ = new QRadioButton(tr("Non"));
-	connect(rb_non_edit_, SIGNAL(clicked()), SIGNAL(NoEditSignal()));
+        rb_non_edit_ = new QRadioButton(tr("Non"));
+        connect(rb_non_edit_, SIGNAL(clicked()), SIGNAL(NoEditSignal()));
 
-	rb_seam_edit_ = new QRadioButton(tr("Edit"));
-	connect(rb_seam_edit_, SIGNAL(clicked()), SIGNAL(SeamEditSignal()));
+        rb_seam_edit_ = new QRadioButton(tr("Dijkstra Edit"));
+        connect(rb_seam_edit_, SIGNAL(clicked()), SIGNAL(SeamEditSignal()));
 
-	QButtonGroup* bg_show_ = new QButtonGroup();
-	bg_show_->setExclusive(true);
-	rb_non_edit_->setChecked(true);
-	bg_show_->addButton(rb_non_edit_);
-	bg_show_->addButton(rb_seam_edit_);
+        rb_geodesic_edit_ = new QRadioButton(tr("Geodesic Edit"));
+        connect(rb_geodesic_edit_, SIGNAL(clicked()), SIGNAL(GeodesicEditSignal()));
+
+        QButtonGroup* bg_show_ = new QButtonGroup();
+        bg_show_->setExclusive(true);
+        rb_non_edit_->setChecked(true);
+        bg_show_->addButton(rb_non_edit_);
+        bg_show_->addButton(rb_seam_edit_);
+        bg_show_->addButton(rb_geodesic_edit_);
 
 	QPushButton* pb_add = new QPushButton(tr("Add"));
 	connect(pb_add, SIGNAL(clicked()), SIGNAL(AddSeamSignal()));
@@ -88,12 +92,13 @@ void MeshParamDialog::CreateCutMeshBox(void)
 	QPushButton* pb_cut = new QPushButton(tr("Mesh Cut"));
 	connect(pb_cut, SIGNAL(clicked()), SIGNAL(MeshCutSignal()));
 
-	QGridLayout* layout_field = new QGridLayout();
-	layout_field->addWidget(rb_non_edit_, 0, 0, 1, 1);
-	layout_field->addWidget(rb_seam_edit_, 0, 1, 1, 1);
-	layout_field->addWidget(pb_undo, 1, 0, 1, 1);
-	layout_field->addWidget(pb_add, 1, 1, 1, 1);
-	layout_field->addWidget(pb_cut, 2, 0, 1, 2);
+        QGridLayout* layout_field = new QGridLayout();
+        layout_field->addWidget(rb_non_edit_, 0, 0, 1, 1);
+        layout_field->addWidget(rb_seam_edit_, 0, 1, 1, 1);
+        layout_field->addWidget(rb_geodesic_edit_, 0, 2, 1, 1);
+        layout_field->addWidget(pb_undo, 1, 0, 1, 1);
+        layout_field->addWidget(pb_add, 1, 1, 1, 1);
+        layout_field->addWidget(pb_cut, 2, 0, 1, 3);
 
 	cut_mesh_box_->setLayout(layout_field);
 }

--- a/MeshViewer/MeshParamDialog.h
+++ b/MeshViewer/MeshParamDialog.h
@@ -23,13 +23,14 @@ private:
 	QTabWidget* tabWidget;
 
 signals:
-	void print_info_signal();
+        void print_info_signal();
 
-	void NoEditSignal();
-	void SeamEditSignal();
-	void AddSeamSignal();
-	void UndoSeamSignal();
-	void MeshCutSignal();
+        void NoEditSignal();
+        void SeamEditSignal();
+        void GeodesicEditSignal();
+        void AddSeamSignal();
+        void UndoSeamSignal();
+        void MeshCutSignal();
 
 	void ChooseModelSignal(int);
 	
@@ -54,10 +55,11 @@ private:
 	void createWidget();
 	void createLayout();
 
-	void CreateCutMeshBox(void);
-	QGroupBox* cut_mesh_box_;
-	QRadioButton* rb_non_edit_;
-	QRadioButton* rb_seam_edit_;
+        void CreateCutMeshBox(void);
+        QGroupBox* cut_mesh_box_;
+        QRadioButton* rb_non_edit_;
+        QRadioButton* rb_seam_edit_;
+        QRadioButton* rb_geodesic_edit_;
 
 	void CreateViewPatchBox(void);
 	QGroupBox* view_patch_box_;


### PR DESCRIPTION
## Summary
- Rename seam editing radio button to “Dijkstra Edit” for clarity
- Add a new “Geodesic Edit” radio button and signal to activate geodesic editing mode
- Wire new signal to viewer and regenerate Qt meta-object code
- Restore `moc_MeshParamDialog.cpp` to the correct generated version

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f116bcb48331b56991346911ae46